### PR TITLE
Remove Node 19 from build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["16.x", "18.x", "19.x", "20.x"]
+        node-version: ["16.x", "18.x", "20.x"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
As of today, it is end of life.