### PR TITLE
Rename `/destination/suggested` to `/destinations/suggested` (with an s)

### DIFF
--- a/dearmep/api/v1.py
+++ b/dearmep/api/v1.py
@@ -238,7 +238,7 @@ def get_destination_by_id(
 
 
 @router.get(
-    "/destination/suggested", operation_id="getSuggestedDestination",
+    "/destinations/suggested", operation_id="getSuggestedDestination",
     response_model=DestinationRead,
 )
 def get_suggested_destination(


### PR DESCRIPTION
Fixes #55.