### PR TITLE
Use one SQLite connection per thread

### DIFF
--- a/server/dearmep/database/connection.py
+++ b/server/dearmep/database/connection.py
@@ -1,5 +1,8 @@
 from contextlib import contextmanager
-from typing import Optional
+import threading
+from typing import Dict
+
+from prometheus_client import Gauge
 
 from sqlalchemy.future import Engine
 from sqlmodel import MetaData, Session, SQLModel, create_engine, select
@@ -7,14 +10,47 @@ from sqlmodel import MetaData, Session, SQLModel, create_engine, select
 from ..config import Config
 
 
+database_engine_refs_total = Gauge(
+    "database_engine_refs_total",
+    "Number of database engine instances held by the AutoEngine class. This "
+    "should be one per thread on non-threadsafe database engines, else 1.",
+)
+
+
 class AutoEngine:
-    engine: Optional[Engine] = None
+    # The engine for each thread, if one has been created already.
+    engines: Dict[int, Engine] = {}
+
+    @staticmethod
+    def engine_is_threadsafe(config: Config) -> bool:
+        """Whether the engine in the config can be considered threadsafe.
+
+        Note that SQLite _can_ be threadsafe (see `sqlite3.threadsafety`), but
+        due to `check_same_thread` in `sqlite3.connect()` defaulting to `True`,
+        even when `sqlite3.threadsafety == 3`, we cannot consider this here."""
+        return not config.database.url.startswith("sqlite")
 
     @classmethod
     def get_engine(cls) -> Engine:
-        if cls.engine is None:
-            cls.engine = create_engine(Config.get().database.url)
-        return cls.engine
+        """Get a (possibly cached) database engine instance."""
+        thread_id = threading.get_ident()
+        # If this thread has a cached engine, return that.
+        if thread_id in cls.engines:
+            return cls.engines[thread_id]
+        # If there is a global engine for all threads, return that.
+        if 0 in cls.engines:
+            return cls.engines[0]
+        # No cached engine available.
+
+        # Check whether we can create a global instance for the DBMS we use.
+        config = Config.get()
+        if cls.engine_is_threadsafe(config):
+            thread_id = 0
+
+        # Create, cache, and return the engine.
+        e = cls.engines[thread_id] = create_engine(Config.get().database.url)
+        database_engine_refs_total.set(len(cls.engines))
+        return e
 
 
 def get_metadata() -> MetaData:

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -72,11 +72,12 @@ def engine_fixture():
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    prev_engine = AutoEngine.engine
-    AutoEngine.engine = memory_engine
+    prev_engine = AutoEngine.engines.get(0, None)
+    AutoEngine.engines[0] = memory_engine
     create_db()
     yield memory_engine
-    AutoEngine.engine = prev_engine
+    if prev_engine:
+        AutoEngine.engines[0] = prev_engine
 
 
 @pytest.fixture(name="session")


### PR DESCRIPTION
Fixes #85.

Before, everything ran on a global connection.

I also had to get rid of the `session` dependency: In FastAPI, dependencies to path operation functions can actually be resolved in a _different_ thread than the one the actual function body will run, see <https://github.com/tiangolo/fastapi/discussions/6069>.

**Note that I’m not sure whether the cached connections will need to be garbage-collected, or whether the threads in FastAPI will be long-lived.** Therefore I’m adding a Prometheus metric that will let us know when the number of cached connections is growing too high.