### PR TITLE
Update build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Collect completed frontend build as an artifact
-        if: ${{ matrix.node-version == '20.x' }}
+        if: ${{ matrix.node-version == '18.x' }}
         uses: actions/upload-artifact@v3
         with:
           name: frontend


### PR DESCRIPTION
Temporarily removing Node 20.x from the matrix build.

Apparently there is an issue in node which in turn breaks babel which in turn breaks our build. 

See the following issues:
https://github.com/nodejs/node/issues/49497
https://github.com/babel/babel/issues/15927

It seems that the fix in node is already merged but not yet rolled out. 
