### PR TITLE
Remove Node.js 16 from build matrix & add 20 back

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["16.x", "18.x", "20.x"]
+        node-version: ["18.x", "20.x"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
16 is EOL, and the issue with 20 (see #118) should’ve been fixed by now.