### PR TITLE
Add portuguese translation

### DIFF
--- a/server/dearmep/example-config.yaml
+++ b/server/dearmep/example-config.yaml
@@ -797,7 +797,7 @@ l10n:
       sv: Vi kommer att ringa dig varje {{ timeSlots }} på ditt nummer för att koppla dig till en Europaparlamentariker från {{ country }}.
       fr: Nous t'appelerons tous les {{ timeSlots }} à ton numéro pour te mettre en contact avec un membre du Parlement européen du / de la {{ country }}.
       da: Vi vil ringe til dig hver {{ timeSlots }} med dit nummer for at forbinde dig med en politiker fra {{ country }}
-      pt: Vamos ligar para o teu número a cada {{ timeSlots }} para te por em contacto com um membro do Parlamento de {{ country }}.
+      pt: Vamos ligar para o teu número a cada {{ timeSlots }} para te por em contacto com um membro do Parlamento Europeu de {{ country }}.
     schedule.timeSlot:
       en: "{{ dayOfWeek }} around {{ time }}"
       de: "{{ dayOfWeek }} um {{ time }}"


### PR DESCRIPTION
Hi, here's the Portuguese translation. I also fixed a small html error in `talkingPoints.moreArgumentsHtml` that was propagated to every language.

I did not setup the server/client locally to see the translation at work, but I did validate the YAML file. Can you deploy this somewhere so I can see it live to check for any contextual/layout weirdness?