### PR TITLE
Disable angular statistics collection

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -183,6 +183,7 @@
       "@cypress/schematic",
       "@angular-eslint/schematics",
       "@schematics/angular"
-    ]
+    ],
+    "analytics": false
   }
 }


### PR DESCRIPTION
When I run `ng serve` I get:
```
? Would you like to share pseudonymous usage data about this project with the Angular Team
at Google under Google's Privacy Policy at https://policies.google.com/privacy. For more
details and how to change this setting, see https://angular.io/analytics. (y/N)
```
I want to set this to "No" and I guess everyone else also wants to have this set to "No"?