### PR TITLE
Add docs page to CORS allow-list

### DIFF
--- a/server/dearmep/example-config.yaml
+++ b/server/dearmep/example-config.yaml
@@ -70,6 +70,7 @@ api:
       - http://localhost:8000
       - https://staging.chatcontrol.dearmep.eu
       - https://chatcontrol.dearmep.eu
+      - https://dearmep.eu
 
   # Rate limit configuration. How often can certain actions/requests be
   # performed before considering it an attack on the service?


### PR DESCRIPTION
Added the URL of the docs-page to the CORS Allow-List so we can embed DearMEP directly in the docs for early demo purposes. 