### PR TITLE
Create infrastructure for disabling rate-limiting for specific IP networks

### DIFF
--- a/server/dearmep/models.py
+++ b/server/dearmep/models.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 from base64 import b64encode
 import enum
 from hashlib import sha256
+from ipaddress import IPv4Network, IPv6Network
 import json
 import re
+from typing import Any, Dict, Generic, List, Literal, Optional, Tuple, \
+    TypeVar, Union
 import secrets
-from typing import Any, Dict, Generic, List, Literal, Optional, Tuple, TypeVar
 
 from canonicaljson import encode_canonical_json
 import phonenumbers
@@ -15,6 +17,7 @@ from pydantic.generics import GenericModel
 
 
 T = TypeVar("T")
+IPNetwork = Union[IPv4Network, IPv6Network]
 
 MAX_SEARCH_RESULT_LIMIT = 20
 

--- a/server/dearmep/phone/elks.py
+++ b/server/dearmep/phone/elks.py
@@ -20,6 +20,13 @@ Duration = int
 FinalState = Literal["success", "failed", "busy"]
 
 
+# This list is from <https://46elks.com/docs/verify-callback-origin>.
+elks_ips: Tuple[str, ...] = (
+    "176.10.154.199", "85.24.146.132", "185.39.146.243",
+    "2001:9b0:2:902::199",
+)
+
+
 def include_router(
     parent: Union[APIRouter, FastAPI],
     base_url: str,
@@ -39,18 +46,13 @@ def include_router(
 
     router = APIRouter()
 
-    # This list is from <https://46elks.com/docs/verify-callback-origin>.
-    elks_ips: Tuple[str, ...] = (
-        "176.10.154.199", "85.24.146.132", "185.39.146.243",
-        "2001:9b0:2:902::199",
-    )
-
+    allowed_ips = elks_ips
     if allow_localhost:
-        elks_ips += ("::1", "127.0.0.1")
+        allowed_ips += ("::1", "127.0.0.1")
 
     async def verify_origin(request: Request):
         client_ip = None if request.client is None else request.client.host
-        if client_ip not in elks_ips:
+        if client_ip not in allowed_ips:
             logger.debug(f"refusing {client_ip}, not a 46elks IP")
             raise HTTPException(
                 status.HTTP_403_FORBIDDEN,


### PR DESCRIPTION
In support for #132

To fully solve #132 the work in PR #125 needs to call into [allow_unlimited](https://github.com/AKVorrat/dearmep/blob/5f0d58b77a593271633d97cb40bb36dc31b50f80/server/dearmep/ratelimit.py#L125) using the [IPs defined in the elks module](https://github.com/AKVorrat/dearmep/blob/5f0d58b77a593271633d97cb40bb36dc31b50f80/server/dearmep/phone/elks.py#L23).