### PR TITLE
Add link to english policy for danish website version

### DIFF
--- a/server/dearmep/example-config.yaml
+++ b/server/dearmep/example-config.yaml
@@ -442,6 +442,7 @@ l10n:
       en: /pages/privacy/en/
       de: /pages/privacy/de/
       sv: /pages/privacy/sv/
+      da: /pages/privacy/en/
       fr: /pages/privacy/fr/
       pt: /pages/privacy/pt/
 


### PR DESCRIPTION
This is mostly to make the tests happy. We need to wait for someone with danish skills that are good enough to properly translate a legal text.