### PR TITLE
Add model & endpoints for user feedback

### DIFF
--- a/server/dearmep/config.py
+++ b/server/dearmep/config.py
@@ -69,6 +69,10 @@ class AuthenticationConfig(BaseModel):
     session: SessionConfig
 
 
+class FeedbackConfig(BaseModel):
+    token_timeout: PositiveInt
+
+
 class ContactTimespanFilterTimespan(BaseModel):
     start: date
     end: date
@@ -207,6 +211,7 @@ class Config(BaseModel):
     authentication: AuthenticationConfig
     contact_timespan_filter: Optional[ContactTimespanFilterConfig]
     database: DatabaseConfig
+    feedback: FeedbackConfig
     l10n: L10nConfig
     telephony: TelephonyConfig
 

--- a/server/dearmep/example-config.yaml
+++ b/server/dearmep/example-config.yaml
@@ -166,6 +166,14 @@ authentication:
     pepper: CHANGE THIS
 
 
+# Options regarding the after-call feedback functionality.
+feedback:
+
+  # How long (in seconds) until the feedback token expires and the User will no
+  # longer be able to use it to enter feedback about that specific call.
+  token_timeout: 604800  # one week
+
+
 # Options regarding phone calls and SMS.
 telephony:
   # If set to true, do not actually send out SMS and make calls.


### PR DESCRIPTION
Implements the feedback form parts of #37.

@t-muehlberger, the endpoints can be used to check whether a token is still valid to be used, and also to provide the Destination data required to display the MEP. I’ve also included a `language` field that you can use to initialize the frontend to; it will be set to the language in use when initiating the call. This is useful if the User opens the feedback form from a different browser (e.g. on their phone).

@t-muehlberger, would you like me to add a mockup version of this to #141? I’d prefer to avoid that, because it’s additional effort to copy-paste the code around and create a mockup for it, but if it makes your life significantly easier I’ll do it nevertheless ;)

@jbethune, if you want to, you can review this. Maybe … idk, react with 👀 on this description when you intend to do one, so that I don’t merge it before you’re done?