### PR TITLE
Add Portuguese campaign staging website

### DIFF
--- a/server/dearmep/example-config.yaml
+++ b/server/dearmep/example-config.yaml
@@ -73,6 +73,7 @@ api:
       - https://digitalcourage.de
 
       - https://chatcontrol.pt
+      - https://staging.chatcontrol.pt
 
       - https://stopscanningme.eu
       - https://stopchatcontrol.eu


### PR DESCRIPTION
We want to test this without deploying it to the production website, so I'm adding a staging website (that doesn't exist yet) to the CORS list.

Is there anything else that needs to be added?