### PR TITLE
Defined "en" as default language in the frontend.

### DIFF
--- a/client/src/app/transloco-root.module.ts
+++ b/client/src/app/transloco-root.module.ts
@@ -35,6 +35,8 @@ export class TranslocoHttpLoader implements TranslocoLoader {
         failedRetries: 0,
         reRenderOnLangChange: true,
         prodMode: !isDevMode(),
+        defaultLang: 'en',
+        availableLangs: [ 'en' ],
         missingHandler: {
           useFallbackTranslation: false
         }


### PR DESCRIPTION
Fixes #197 

Seems to have been a timing issue where the language settings from the server arrive too late in some cases. Fixed by hard-coding the transloco defaultLanguage to "en" and availableLanguages to [ "en" ] . These settings are then overridden by the server-response as soon as it arrives. 