### PR TITLE
fix recommender bug from issue 203

### DIFF
--- a/server/dearmep/database/query.py
+++ b/server/dearmep/database/query.py
@@ -445,7 +445,8 @@ def get_recommended_destination(
     else:
         final_dest_id = None
 
-    if not final_dest_id:
+    # TODO: Remove the `not in` check once we're sure that it can't happen.
+    if not final_dest_id or final_dest_id not in destinations:
         raise NotFound("no destination found that could be recommended")
 
     final_dest = destinations[final_dest_id]


### PR DESCRIPTION
The bug described in https://github.com/AKVorrat/dearmep/issues/203 comes from adding a score to `merged_scores` for a destination not existing in `merged_scores`.

This fix makes sure a score is only altered, but no new score for a new id is falsely introduced.