### PR TITLE
fix office hours check

### DIFF
--- a/client/src/app/services/office-hours/office-hours.service.ts
+++ b/client/src/app/services/office-hours/office-hours.service.ts
@@ -6,7 +6,7 @@ import { DayOfWeek } from 'src/app/model/day-of-week.enum';
 import { TimeOfDay } from 'src/app/model/time-of-day';
 import { TimeService } from '../time/time.service';
 import { TranslocoService } from '@ngneat/transloco';
-import { environment } from 'src/environments/environment.development';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
Fixes #215 

I guess the workaround for disabling the office-hours check during testing worked a little bit too well. As @scy already mentioned, we really do need server-side configuration. 