### PR TITLE
Fix frontend build instructions

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -32,11 +32,11 @@ Run `npm run build` and `npm run start:test-page`. Navigate to `http://localhost
 
 ## Code scaffolding
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Run `npx ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
 
 ## Build
 
-Run `npm build` to build the project. The build artifacts will be stored in the `dist/dear-mep-bundle/` directory.
+Run `npm run build` to build the project. The build artifacts will be stored in the `dist/dear-mep-bundle/` directory.
 
 ## Lint
 
@@ -48,4 +48,4 @@ Run `npm test` to execute the unit tests via [Karma](https://karma-runner.github
 
 ## Running end-to-end tests
 
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
+Run `npx ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.


### PR DESCRIPTION
Also replaces some `ng` usages with the equivalent script in `package.json`.

@t-muehlberger: As discussed on Signal. Feel free to make whatever changes you’d like to add – or don’t, if you don’t have time – and merge.