### PR TITLE
Add an interval config

### DIFF
--- a/server/dearmep/api/v1.py
+++ b/server/dearmep/api/v1.py
@@ -230,6 +230,7 @@ def get_frontend_setup(
         location=l10n_res.location,
         frontend_strings=l10n_res.frontend_strings,
         office_hours=OfficeHoursResponse(
+            call_schedule_interval=hours.call_schedule_interval,
             timezone=hours.timezone,
             weekdays=hours.intervals_by_weekday(),
         ),

--- a/server/dearmep/config.py
+++ b/server/dearmep/config.py
@@ -224,6 +224,7 @@ class OfficeHoursConfig(BaseModel):
     weekdays: Set[WeekdayNumber]
     begin: time
     end: time
+    call_schedule_interval: PositiveInt = 15
 
     @validator("begin", "end")
     def no_timezone_in_begin_and_end(cls, v: time) -> time:

--- a/server/dearmep/example-config.yaml
+++ b/server/dearmep/example-config.yaml
@@ -227,6 +227,8 @@ telephony:
   # It does not make sense to call representatives' offices in the middle of
   # the night. Therefore, you can configure "office hours". Outside of the time
   # range defined here, starting new calls will not be possible.
+  # Keep in mind that changing office hours in a running campaign _might_ lead to
+  # scheduled calls being outside of it, effectively disabling some.
   office_hours:
 
     # A Olson timezone identifier. Will be used both by pytz in the backend as
@@ -245,6 +247,11 @@ telephony:
     # not possible. Both restrictions might be removed in a future version.
     begin: "09:00"
     end: "20:00"
+
+    # The interval of timeslots offered to the User to schedule calls. The
+    # frontend generates a list of timeslots between 'begin' and 'end' from
+    # this value.
+    call_schedule_interval: 15  # minutes
 
   # Calling codes that we allow Users to have. This corresponds to the "country
   # code" part of an international phone number. For example, the number

--- a/server/dearmep/models.py
+++ b/server/dearmep/models.py
@@ -13,7 +13,7 @@ import secrets
 from canonicaljson import encode_canonical_json
 import phonenumbers
 from pydantic import BaseModel, ConstrainedFloat, ConstrainedInt, \
-    ConstrainedStr, Field, validator
+    ConstrainedStr, Field, PositiveInt, validator
 from pydantic.generics import GenericModel
 
 
@@ -557,6 +557,10 @@ class OfficeHoursInterval(BaseModel):
 
 
 class OfficeHoursResponse(BaseModel):
+    call_schedule_interval: PositiveInt = Field(
+        description="The interval between possible schedule times in minutes.",
+        example=15,
+    )
     timezone: str = Field(
         description="The Olson timezone specifier used for the office hours.",
         example="Europe/Brussels",

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -18,6 +18,7 @@ EXAMPLE_HOURS = OfficeHoursConfig.parse_obj({
     "weekdays": (1, 2, 3, 4, 5),
     "begin": "09:00",
     "end": "18:00",
+    "call_schedule_interval": 15,
 })
 
 


### PR DESCRIPTION
This adds `call_schedule_interval` to the office hours configuration section and sends it as `call_schedule_interval`  in in the `OfficeHoursResponse` at the endpoint `getFrontendSetup`.

@t-muehlberger @scy 