### PR TITLE
Enable scheduling by default in the frontend

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -52,8 +52,6 @@ export class AppComponent implements OnInit, OnChanges {
   /**
    * This parameter hides the call-scheduling functionality. By default scheduling is enabled.
    *
-   * NOTE: Sceduling is currently disabled by default as the backend does not yet support the functionality.
-   *
    * It can be applied in the HTML code by simply specifying the attribute-name:
    *
    *  <dear-mep disable-scheduling></dear-mep>
@@ -62,7 +60,7 @@ export class AppComponent implements OnInit, OnChanges {
    * The getter 'disableScheduling' converts this value into a boolean accordinly.
    */
   @Input()
-  public 'disable-scheduling': '' | undefined = '' // NOTE: This default will be changed to false as soon as scheduling is implemented in the backend.
+  public 'disable-scheduling': '' | undefined = undefined
 
   public get disableScheduling(): boolean {
     return this.convertBooleanAttribute(this['disable-scheduling'])


### PR DESCRIPTION
#233 implemented the scheduling functionality in the frontend but since changing the default will have an impact on existing deployments it is still disabled by default. This PR enables scheduling by default in the frontend. 

@scy do you think we should merge this now or would you rather wait a bit longer with this change. Feel free to merge the PR whenever you think it makes sense. 

Note: Scheduling can now (after #233) also be enabled using `disable-scheduling="false"`.  