### PR TITLE
Update python-multipart to 0.0.7

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -1589,17 +1589,17 @@ pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.6"
+version = "0.0.7"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "python_multipart-0.0.6-py3-none-any.whl", hash = "sha256:ee698bab5ef148b0a760751c261902cd096e57e10558e11aca17646b74ee1c18"},
-    {file = "python_multipart-0.0.6.tar.gz", hash = "sha256:e9925a80bb668529f1b67c7fdb0a5dacdd7cbfc6fb0bff3ea443fe22bdd62132"},
+    {file = "python_multipart-0.0.7-py3-none-any.whl", hash = "sha256:b1fef9a53b74c795e2347daac8c54b252d9e0df9c619712691c1cc8021bd3c49"},
+    {file = "python_multipart-0.0.7.tar.gz", hash = "sha256:288a6c39b06596c1b988bb6794c6fbc80e6c369e35e5062637df256bee0c9af9"},
 ]
 
 [package.extras]
-dev = ["atomicwrites (==1.2.1)", "attrs (==19.2.0)", "coverage (==6.5.0)", "hatch", "invoke (==1.7.3)", "more-itertools (==4.3.0)", "pbr (==4.3.0)", "pluggy (==1.0.0)", "py (==1.11.0)", "pytest (==7.2.0)", "pytest-cov (==4.0.0)", "pytest-timeout (==2.1.0)", "pyyaml (==5.1)"]
+dev = ["atomicwrites (==1.2.1)", "attrs (==19.2.0)", "coverage (==6.5.0)", "hatch", "invoke (==2.2.0)", "more-itertools (==4.3.0)", "pbr (==4.3.0)", "pluggy (==1.0.0)", "py (==1.11.0)", "pytest (==7.2.0)", "pytest-cov (==4.0.0)", "pytest-timeout (==2.1.0)", "pyyaml (==5.1)"]
 
 [[package]]
 name = "python-slugify"
@@ -2484,4 +2484,4 @@ specs = ["eralchemy2"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a855e8a7ed0bd4d4b546d3220bd9203671825a0d3751ddecec4281a746575d84"
+content-hash = "db048f6850d919e9ff3cb95cd9ad1ce949bf3a9e905994da51a5fb5c135fb7d9"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -34,7 +34,7 @@ ratelimit = "^2.2.1"
 python-dotenv = "^1.0.0"
 jinja2 = "^3.1.2"
 markdown-it-py = "^2.2"
-python-multipart = "^0.0.6"
+python-multipart = "^0.0.7"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 types-python-jose = "^3.3.4.8"
 xlsxwriter = {version = "^3.1.5", optional = true}


### PR DESCRIPTION
Resolves ReDoS CVE-2024-24762. We only use multipart forms when talking to the Elks anyway, so the risk of someone exploiting this on the current production instance is small.