### PR TITLE
Remove deprecated getLocalization endpoint

### DIFF
--- a/server/dearmep/api/v1.py
+++ b/server/dearmep/api/v1.py
@@ -129,41 +129,6 @@ def _get_localization(
     )
 
 
-@router.get(
-    "/localization", operation_id="getLocalization",
-    response_model=LocalizationResponse,
-    responses=rate_limit_response,  # type: ignore[arg-type]
-    dependencies=(computational_rate_limit,),
-    deprecated=True,
-)
-def get_localization(
-    frontend_strings: bool = Query(
-        False,
-        description="Whether to also include all frontend translation strings "
-        "for the detected language. If you don’t request this, the "
-        "`frontend_strings` field in the response will be `null` to save "
-        "bandwidth.",
-    ),
-    client_addr: str = Depends(client_addr),
-    accept_language: str = Header(""),
-):
-    """
-    Based on the user’s IP address and `Accept-Language` header, suggest a
-    country and language from the ones available in the campaign.
-
-    See the `/frontend-strings` endpoint for additional information on the
-    `frontend_strings` field.
-
-    **Deprecated:** Use `/frontend-setup` instead. It expects the same input
-    parameters, but provides more information, e.g. office hours.
-    """
-    return _get_localization(
-        frontend_strings=frontend_strings,
-        client_addr=client_addr,
-        accept_language=accept_language,
-    )
-
-
 # TODO: Add caching headers, this is pretty static data.
 @router.get(
     "/frontend-strings/{language}", operation_id="getFrontendStrings",

--- a/server/tests/api/test_api_l10n.py
+++ b/server/tests/api/test_api_l10n.py
@@ -18,7 +18,7 @@ def test_l10n(
 ):
     override_client_addr(fastapi_app, "2a01:4f8::1")
     res = client.get(
-        "/api/v1/localization",
+        "/api/v1/frontend-setup",
         headers={
             "Accept-Language": "tlh;q=1, en;q=0.8",
         }
@@ -64,16 +64,16 @@ def test_l10n(
 def test_l10n_without_addr_override(client: TestClient):
     # Do a request without overriding the address, mainly for coverage of the
     # real address dependable.
-    res = client.get("/api/v1/localization")
+    res = client.get("/api/v1/frontend-setup")
     assert res.status_code == status.HTTP_200_OK
 
 
 def test_l10n_ratelimit(fastapi_app: FastAPI, client: TestClient):
     override_client_addr(fastapi_app, "2a01:abc::1")
     for _ in range(5):
-        res = client.get("/api/v1/localization")
+        res = client.get("/api/v1/frontend-setup")
         assert res.status_code == status.HTTP_200_OK
-    res = client.get("/api/v1/localization")
+    res = client.get("/api/v1/frontend-setup")
     assert res.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
 
@@ -85,11 +85,11 @@ def test_l10n_ratelimit_v6(fastapi_app: FastAPI, client: TestClient):
         if i % 5 == 0:
             new_addr = f"2a01:abc::{i // 5 + 1}"
             override_client_addr(fastapi_app, new_addr)
-        res = client.get("/api/v1/localization")
+        res = client.get("/api/v1/frontend-setup")
         assert res.status_code == status.HTTP_200_OK
-    res = client.get("/api/v1/localization")
+    res = client.get("/api/v1/frontend-setup")
     assert res.status_code == status.HTTP_429_TOO_MANY_REQUESTS
     # With a different /64 it should still work though.
     override_client_addr(fastapi_app, "2a01:abc:0:1::1")
-    res = client.get("/api/v1/localization")
+    res = client.get("/api/v1/frontend-setup")
     assert res.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Replace it, as suggested in the deprecation notice, with /frontend-setup.

Fixes #266.