### PR TITLE
Update FastAPI, python-multipart, and mypy

### DIFF
--- a/server/dearmep/api/v1.py
+++ b/server/dearmep/api/v1.py
@@ -82,7 +82,10 @@ l10n_autodetect_total = Counter(
 )
 
 
-rate_limit_response: dict[int, dict[str, Any]] = {
+# This is typehinted as Union[int, str] even though the keys are just ints
+# because of <https://github.com/python/mypy/issues/16072>. The
+# `**rate_limit_response` instances below would cause mypy errors otherwise.
+rate_limit_response: dict[Union[int, str], dict[str, Any]] = {
     429: {
         "description": "Rate Limit Exceeded",
         "model": RateLimitResponse,
@@ -181,7 +184,7 @@ def _get_localization(
     "/frontend-strings/{language}",
     operation_id="getFrontendStrings",
     response_model=FrontendStringsResponse,
-    responses=rate_limit_response,  # type: ignore[arg-type]
+    responses=rate_limit_response,
     dependencies=(simple_rate_limit,),
 )
 def get_frontend_strings(
@@ -207,7 +210,7 @@ def get_frontend_strings(
     "/frontend-setup",
     operation_id="getFrontendSetup",
     response_model=FrontendSetupResponse,
-    responses=rate_limit_response,  # type: ignore[arg-type]
+    responses=rate_limit_response,
     dependencies=(computational_rate_limit,),
 )
 def get_frontend_setup(
@@ -260,7 +263,7 @@ def get_frontend_setup(
     operation_id="getBlob",
     response_class=Response,
     responses={
-        **rate_limit_response,  # type: ignore[arg-type]
+        **rate_limit_response,
         200: {
             "content": {"application/octet-stream": {}},
             "description": "The contents of the named blob, with a matching "
@@ -288,7 +291,7 @@ def get_blob_contents(
     operation_id="getDestinationsByCountry",
     summary="Get Destinations by Country",
     response_model=SearchResult[DestinationSearchResult],
-    responses=rate_limit_response,  # type: ignore[arg-type]
+    responses=rate_limit_response,
     dependencies=(simple_rate_limit,),
 )
 def get_destinations_by_country(
@@ -306,13 +309,13 @@ def get_destinations_by_country(
     operation_id="getDestinationsByName",
     summary="Get Destinations by Name",
     response_model=SearchResult[DestinationSearchResult],
-    responses=rate_limit_response,  # type: ignore[arg-type]
+    responses=rate_limit_response,
     dependencies=(simple_rate_limit,),
 )
 def get_destinations_by_name(
     name: str = Query(
         description="The (part of the) name to search for.",
-        example="miers",
+        examples=["miers"],
     ),
     all_countries: bool = Query(
         True,
@@ -325,12 +328,12 @@ def get_destinations_by_name(
         description="The country to search in (if `all_countries` is false) "
         "or prefer (if `all_countries` is true). Has to be specified if "
         "`all_countries` is false.",
-        example="DE",
+        examples=["DE"],
     ),
     limit: SearchResultLimit = Query(
         MAX_SEARCH_RESULT_LIMIT,
         description="Maximum number of results to be returned.",
-        example=MAX_SEARCH_RESULT_LIMIT,
+        examples=[MAX_SEARCH_RESULT_LIMIT],
     ),
 ) -> SearchResult[DestinationSearchResult]:
     """Return Destinations by searching for (parts of) their name."""
@@ -355,7 +358,7 @@ def get_destinations_by_name(
     operation_id="getDestinationByID",
     summary="Get Destination by ID",
     response_model=DestinationRead,
-    responses=rate_limit_response,  # type: ignore[arg-type]
+    responses=rate_limit_response,
     dependencies=(simple_rate_limit,),
 )
 def get_destination_by_id(
@@ -374,7 +377,7 @@ def get_destination_by_id(
     "/destinations/suggested",
     operation_id="getSuggestedDestination",
     response_model=DestinationRead,
-    responses=rate_limit_response,  # type: ignore[arg-type]
+    responses=rate_limit_response,
     dependencies=(computational_rate_limit,),
 )
 def get_suggested_destination(
@@ -417,7 +420,7 @@ def get_suggested_destination(
     operation_id="initiateCall",
     response_model=CallStateResponse,
     responses={
-        **rate_limit_response,  # type: ignore[arg-type]
+        **rate_limit_response,
         503: {
             "model": Union[
                 DestinationInCallResponse,
@@ -475,7 +478,7 @@ def initiate_call(
     "/call/state",
     operation_id="getCallState",
     response_model=CallStateResponse,
-    responses=rate_limit_response,  # type: ignore[arg-type]
+    responses=rate_limit_response,
     dependencies=(simple_rate_limit,),
 )
 def get_call_state(
@@ -506,7 +509,7 @@ def get_call_state(
     "/number-verification/request",
     operation_id="requestNumberVerification",
     responses={
-        **rate_limit_response,  # type: ignore[arg-type]
+        **rate_limit_response,
         400: {"model": PhoneNumberVerificationRejectedResponse},
     },
     response_model=PhoneNumberVerificationResponse,
@@ -573,7 +576,7 @@ def request_number_verification(
     "/number-verification/verify",
     operation_id="verifyNumber",
     responses={
-        **rate_limit_response,  # type: ignore[arg-type]
+        **rate_limit_response,
         400: {"model": SMSCodeVerificationFailedResponse},
     },
     response_model=JWTResponse,
@@ -611,7 +614,7 @@ def verify_number(
     operation_id="getFeedbackContext",
     response_model=FeedbackContext,
     responses={
-        **rate_limit_response,  # type: ignore[arg-type]
+        **rate_limit_response,
         404: {"description": "Token Not Found"},
     },
     dependencies=(simple_rate_limit,),
@@ -650,7 +653,7 @@ def get_feedback_context(
     operation_id="submitCallFeedback",
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
-        **rate_limit_response,  # type: ignore[arg-type]
+        **rate_limit_response,
         403: {"description": "Token Already Used"},
         404: {"description": "Token Not Found"},
     },
@@ -689,7 +692,7 @@ def submit_call_feedback(
     "/schedule",
     operation_id="getSchedule",
     response_model=ScheduleResponse,
-    responses=rate_limit_response,  # type: ignore[arg-type]
+    responses=rate_limit_response,
     dependencies=(simple_rate_limit,),
 )
 def get_schedule(
@@ -708,7 +711,7 @@ def get_schedule(
     "/schedule",
     operation_id="setSchedule",
     response_model=ScheduleResponse,
-    responses=rate_limit_response,  # type: ignore[arg-type]
+    responses=rate_limit_response,
     dependencies=(simple_rate_limit,),
 )
 def set_schedule(

--- a/server/dearmep/cli/__init__.py
+++ b/server/dearmep/cli/__init__.py
@@ -35,13 +35,13 @@ class Context:
         self.dummy_factory = DummyTaskFactory()
 
     def setup_logging(self, level: int = logging.INFO) -> None:
-        def ignore_uninteresting(r: logging.LogRecord) -> int:
+        def ignore_uninteresting(r: logging.LogRecord) -> bool:
             ratelimit_backoff = re.compile(
                 r"^Backing off .+\(ratelimit.exception.RateLimitException"
             )
-            if r.name == "backoff" and ratelimit_backoff.match(r.getMessage()):
-                return 0
-            return 1
+            if r.name == "backoff" and ratelimit_backoff.match(r.getMessage()):  # noqa: SIM103
+                return False
+            return True
 
         handler = RichHandler(
             console=self.console,

--- a/server/dearmep/config.py
+++ b/server/dearmep/config.py
@@ -460,7 +460,7 @@ class Settings(BaseSettings):
     """Settings supplied via environment variables."""
 
     config_file: FilePath = Field(
-        "config.yaml",
+        Path("config.yaml"),
         env={f"{ENV_PREFIX}CONFIG", f"{ENV_PREFIX}CONFIG_FILE"},  # allow both
     )
     demo_page: bool = Field(

--- a/server/dearmep/progress.py
+++ b/server/dearmep/progress.py
@@ -204,7 +204,8 @@ class TrackingBytesReader(BufferedReader, TrackingMixin):  # type: ignore[misc]
 
 class TrackingStrReader(TextIOWrapper, TrackingMixin):  # type: ignore[misc]
     def read(self, size: Optional[int] = -1) -> str:
-        return self._with_tracking(super().read(size), self.buffer.tell)
+        # FIXME: self.buffer.tell _works_, but is not guaranteed.
+        return self._with_tracking(super().read(size), self.buffer.tell)  # type: ignore[attr-defined]
 
     def readline(  # type: ignore[override]
         self,
@@ -212,7 +213,8 @@ class TrackingStrReader(TextIOWrapper, TrackingMixin):  # type: ignore[misc]
     ) -> str:
         return self._with_tracking(
             super().readline(-1 if size is None else size),
-            self.buffer.tell,
+            # FIXME: self.buffer.tell _works_, but is not guaranteed.
+            self.buffer.tell,  # type: ignore[attr-defined]
         )
 
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 	"countryguess~=0.3.0",
 	"defusedxml~=0.7.1",
 	"fastapi-restful~=0.5.0",
-	"fastapi~=0.95.1",
+	"fastapi~=0.115.6",
 	"httpx~=0.23.3",
 	"jinja2~=3.1.2",
 	"limits~=3.14",
@@ -34,7 +34,7 @@ dependencies = [
 	"python-dotenv~=1.0.0",
 	"python-geoacumen>=2023",
 	"python-jose[cryptography]~=3.3.0",
-	"python-multipart~=0.0.7",
+	"python-multipart~=0.0.20",
 	"pytz~=2023.3.post1",
 	"pyyaml~=6.0",
 	"ratelimit~=2.2.1",
@@ -48,7 +48,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-	"mypy<1.0",
+	"mypy~=1.13.0",
 	"py-mmdb-encoder~=1.0.4",
 	"pytest-cov~=4.0.0",
 	"pytest<8",
@@ -98,6 +98,7 @@ artifacts = [
 
 [tool.mypy]
 packages = ["dearmep", "tests"]
+plugins = ["pydantic.mypy"]
 python_version = "3.9"
 warn_return_any = true
 

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -417,7 +417,7 @@ requires-dist = [
     { name = "csvkit", marker = "extra == 'convert'", specifier = ">=2" },
     { name = "defusedxml", specifier = "~=0.7.1" },
     { name = "eralchemy2", marker = "extra == 'specs'", specifier = "~=1.4" },
-    { name = "fastapi", specifier = "~=0.95.1" },
+    { name = "fastapi", specifier = "~=0.115.6" },
     { name = "fastapi-restful", specifier = "~=0.5.0" },
     { name = "httpx", specifier = "~=0.23.3" },
     { name = "jinja2", specifier = "~=3.1.2" },
@@ -430,7 +430,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "~=1.0.0" },
     { name = "python-geoacumen", specifier = ">=2023" },
     { name = "python-jose", extras = ["cryptography"], specifier = "~=3.3.0" },
-    { name = "python-multipart", specifier = "~=0.0.7" },
+    { name = "python-multipart", specifier = "~=0.0.20" },
     { name = "pytz", specifier = "~=2023.3.post1" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "ratelimit", specifier = "~=2.2.1" },
@@ -446,7 +446,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = "<1.0" },
+    { name = "mypy", specifier = "~=1.13.0" },
     { name = "py-mmdb-encoder", specifier = "~=1.0.4" },
     { name = "pytest", specifier = "<8" },
     { name = "pytest-cov", specifier = "~=4.0.0" },
@@ -526,15 +526,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.95.1"
+version = "0.115.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/7b/ec011cf46d78627159ab869556f246b5f823a6df8d94f7577e043a63fffd/fastapi-0.95.1.tar.gz", hash = "sha256:9569f0a381f8a457ec479d90fa01005cfddaae07546eb1f3fa035bc4797ae7d5", size = 10045151 }
+sdist = { url = "https://files.pythonhosted.org/packages/93/72/d83b98cd106541e8f5e5bfab8ef2974ab45a62e8a6c5b5e6940f26d2ed4b/fastapi-0.115.6.tar.gz", hash = "sha256:9ec46f7addc14ea472958a96aae5b5de65f39721a46aaf5705c480d9a8b76654", size = 301336 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/84/d289e941ffec2f107d9097c8f7c2dbc874b0fc3fab9776aa3cc366d45ab2/fastapi-0.95.1-py3-none-any.whl", hash = "sha256:a870d443e5405982e1667dfe372663abf10754f246866056336d7f01c21dab07", size = 56968 },
+    { url = "https://files.pythonhosted.org/packages/52/b3/7e4df40e585df024fac2f80d1a2d579c854ac37109675db2b0cc22c0bb9e/fastapi-0.115.6-py3-none-any.whl", hash = "sha256:e9240b29e36fa8f4bb7290316988e90c381e5092e0cbe84e7818cc3713bcf305", size = 94843 },
 ]
 
 [[package]]
@@ -912,43 +913,50 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "0.991"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/5c/fbe112ca73d4c6a9e65336f48099c60800514d8949b4129c093a84a28dc8/mypy-0.991.tar.gz", hash = "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06", size = 2688198 }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/21/7e9e523537991d145ab8a0a2fd98548d67646dc2aaaf6091c31ad883e7c1/mypy-1.13.0.tar.gz", hash = "sha256:0291a61b6fbf3e6673e3405cfcc0e7650bebc7939659fdca2702958038bd835e", size = 3152532 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/d0/81d47bffc80d0cff84174aab266adc3401e735e13c5613418e825c146986/mypy-0.991-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab", size = 18805560 },
-    { url = "https://files.pythonhosted.org/packages/d7/f4/dcab9f3c5ed410caca1b9374dbb2b2caa778d225e32f174e266e20291edf/mypy-0.991-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d", size = 11117673 },
-    { url = "https://files.pythonhosted.org/packages/87/ec/62fd00fa5d8ead3ecafed3eb99ee805911f41b11536c5940df1bcb2c845d/mypy-0.991-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6", size = 10023879 },
-    { url = "https://files.pythonhosted.org/packages/39/05/7a7d58afc7d00e819e553ad2485a29141e14575e3b0c43b9da6f869ede4c/mypy-0.991-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb", size = 18209901 },
-    { url = "https://files.pythonhosted.org/packages/80/23/76e56e004acca691b4da4086a8c38bd67b7ae73536848dcab76cfed5c188/mypy-0.991-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305", size = 19680479 },
-    { url = "https://files.pythonhosted.org/packages/f3/1d/cc67a674f1cd7f1c10619487a4245185f6f8f14cbd685b60709318e9ac27/mypy-0.991-cp310-cp310-win_amd64.whl", hash = "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c", size = 8670519 },
-    { url = "https://files.pythonhosted.org/packages/b8/ab/aa2e02fce8ee8885fe98ee2a0549290e9de5caa28febc0cf243bfab020e7/mypy-0.991-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372", size = 18600640 },
-    { url = "https://files.pythonhosted.org/packages/28/9c/e1805f2fea93a92671f33b00dd577119f37e4a8b859d6f6ea62d3e9129fa/mypy-0.991-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f", size = 11004105 },
-    { url = "https://files.pythonhosted.org/packages/df/bb/3cf400e05e30939a0fc58b34e0662d8abe8e206464665065b56cf2ca9a62/mypy-0.991-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33", size = 9939717 },
-    { url = "https://files.pythonhosted.org/packages/14/05/5a4206e269268f4aecb1096bf2375a231c959987ccf3e31313221b8bc153/mypy-0.991-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05", size = 18068884 },
-    { url = "https://files.pythonhosted.org/packages/4b/98/125e5d14222de8e92f44314f8df21a9c351b531b37c551526acd67486a7d/mypy-0.991-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad", size = 19451243 },
-    { url = "https://files.pythonhosted.org/packages/89/76/7159258fdbf26a5ceef100b80a82d2f79b9066725a5daeb6383a8f773910/mypy-0.991-cp311-cp311-win_amd64.whl", hash = "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297", size = 8666646 },
-    { url = "https://files.pythonhosted.org/packages/bc/b2/6e71e47b259992dcd99d257ce452c0de3f711be713d048fe8f0fda9a9996/mypy-0.991-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d", size = 18797275 },
-    { url = "https://files.pythonhosted.org/packages/6b/22/5e19d1a6f8e029296e7b2fa462d8753fb4365126684c2f840dcb1447e6e8/mypy-0.991-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5", size = 11110665 },
-    { url = "https://files.pythonhosted.org/packages/91/27/716b1cfce990cb58dc92f6601852141bc25e1524c06b3f3a39b0de6d9210/mypy-0.991-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3", size = 10025615 },
-    { url = "https://files.pythonhosted.org/packages/e9/7e/cc2de45afb46fee694bf285f91df3e227a3b0c671f775524814549c26556/mypy-0.991-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648", size = 18168365 },
-    { url = "https://files.pythonhosted.org/packages/ac/a6/e4d6dca539c637735d0d93f1eee3ac35cedfd9c047da7386b3a59e93f35b/mypy-0.991-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476", size = 19630805 },
-    { url = "https://files.pythonhosted.org/packages/ca/0d/da98f81e7c13a60111dc10a16cbf1b48dc8500df90a1fc959878a5981f49/mypy-0.991-cp39-cp39-win_amd64.whl", hash = "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461", size = 8668900 },
-    { url = "https://files.pythonhosted.org/packages/e7/a1/c503a15ad69ff133a76c159b8287f0eadc1f521d9796bf81f935886c98f6/mypy-0.991-py3-none-any.whl", hash = "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb", size = 2307767 },
+    { url = "https://files.pythonhosted.org/packages/5e/8c/206de95a27722b5b5a8c85ba3100467bd86299d92a4f71c6b9aa448bfa2f/mypy-1.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6607e0f1dd1fb7f0aca14d936d13fd19eba5e17e1cd2a14f808fa5f8f6d8f60a", size = 11020731 },
+    { url = "https://files.pythonhosted.org/packages/ab/bb/b31695a29eea76b1569fd28b4ab141a1adc9842edde080d1e8e1776862c7/mypy-1.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8a21be69bd26fa81b1f80a61ee7ab05b076c674d9b18fb56239d72e21d9f4c80", size = 10184276 },
+    { url = "https://files.pythonhosted.org/packages/a5/2d/4a23849729bb27934a0e079c9c1aad912167d875c7b070382a408d459651/mypy-1.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b2353a44d2179846a096e25691d54d59904559f4232519d420d64da6828a3a7", size = 12587706 },
+    { url = "https://files.pythonhosted.org/packages/5c/c3/d318e38ada50255e22e23353a469c791379825240e71b0ad03e76ca07ae6/mypy-1.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0730d1c6a2739d4511dc4253f8274cdd140c55c32dfb0a4cf8b7a43f40abfa6f", size = 13105586 },
+    { url = "https://files.pythonhosted.org/packages/4a/25/3918bc64952370c3dbdbd8c82c363804678127815febd2925b7273d9482c/mypy-1.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:c5fc54dbb712ff5e5a0fca797e6e0aa25726c7e72c6a5850cfd2adbc1eb0a372", size = 9632318 },
+    { url = "https://files.pythonhosted.org/packages/d0/19/de0822609e5b93d02579075248c7aa6ceaddcea92f00bf4ea8e4c22e3598/mypy-1.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:581665e6f3a8a9078f28d5502f4c334c0c8d802ef55ea0e7276a6e409bc0d82d", size = 10939027 },
+    { url = "https://files.pythonhosted.org/packages/c8/71/6950fcc6ca84179137e4cbf7cf41e6b68b4a339a1f5d3e954f8c34e02d66/mypy-1.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3ddb5b9bf82e05cc9a627e84707b528e5c7caaa1c55c69e175abb15a761cec2d", size = 10108699 },
+    { url = "https://files.pythonhosted.org/packages/26/50/29d3e7dd166e74dc13d46050b23f7d6d7533acf48f5217663a3719db024e/mypy-1.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20c7ee0bc0d5a9595c46f38beb04201f2620065a93755704e141fcac9f59db2b", size = 12506263 },
+    { url = "https://files.pythonhosted.org/packages/3f/1d/676e76f07f7d5ddcd4227af3938a9c9640f293b7d8a44dd4ff41d4db25c1/mypy-1.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3790ded76f0b34bc9c8ba4def8f919dd6a46db0f5a6610fb994fe8efdd447f73", size = 12984688 },
+    { url = "https://files.pythonhosted.org/packages/9c/03/5a85a30ae5407b1d28fab51bd3e2103e52ad0918d1e68f02a7778669a307/mypy-1.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:51f869f4b6b538229c1d1bcc1dd7d119817206e2bc54e8e374b3dfa202defcca", size = 9626811 },
+    { url = "https://files.pythonhosted.org/packages/fb/31/c526a7bd2e5c710ae47717c7a5f53f616db6d9097caf48ad650581e81748/mypy-1.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5c7051a3461ae84dfb5dd15eff5094640c61c5f22257c8b766794e6dd85e72d5", size = 11077900 },
+    { url = "https://files.pythonhosted.org/packages/83/67/b7419c6b503679d10bd26fc67529bc6a1f7a5f220bbb9f292dc10d33352f/mypy-1.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:39bb21c69a5d6342f4ce526e4584bc5c197fd20a60d14a8624d8743fffb9472e", size = 10074818 },
+    { url = "https://files.pythonhosted.org/packages/ba/07/37d67048786ae84e6612575e173d713c9a05d0ae495dde1e68d972207d98/mypy-1.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:164f28cb9d6367439031f4c81e84d3ccaa1e19232d9d05d37cb0bd880d3f93c2", size = 12589275 },
+    { url = "https://files.pythonhosted.org/packages/1f/17/b1018c6bb3e9f1ce3956722b3bf91bff86c1cefccca71cec05eae49d6d41/mypy-1.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a4c1bfcdbce96ff5d96fc9b08e3831acb30dc44ab02671eca5953eadad07d6d0", size = 13037783 },
+    { url = "https://files.pythonhosted.org/packages/cb/32/cd540755579e54a88099aee0287086d996f5a24281a673f78a0e14dba150/mypy-1.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0affb3a79a256b4183ba09811e3577c5163ed06685e4d4b46429a271ba174d2", size = 9726197 },
+    { url = "https://files.pythonhosted.org/packages/11/bb/ab4cfdc562cad80418f077d8be9b4491ee4fb257440da951b85cbb0a639e/mypy-1.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a7b44178c9760ce1a43f544e595d35ed61ac2c3de306599fa59b38a6048e1aa7", size = 11069721 },
+    { url = "https://files.pythonhosted.org/packages/59/3b/a393b1607cb749ea2c621def5ba8c58308ff05e30d9dbdc7c15028bca111/mypy-1.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5d5092efb8516d08440e36626f0153b5006d4088c1d663d88bf79625af3d1d62", size = 10063996 },
+    { url = "https://files.pythonhosted.org/packages/d1/1f/6b76be289a5a521bb1caedc1f08e76ff17ab59061007f201a8a18cc514d1/mypy-1.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2904956dac40ced10931ac967ae63c5089bd498542194b436eb097a9f77bc8", size = 12584043 },
+    { url = "https://files.pythonhosted.org/packages/a6/83/5a85c9a5976c6f96e3a5a7591aa28b4a6ca3a07e9e5ba0cec090c8b596d6/mypy-1.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:7bfd8836970d33c2105562650656b6846149374dc8ed77d98424b40b09340ba7", size = 13036996 },
+    { url = "https://files.pythonhosted.org/packages/b4/59/c39a6f752f1f893fccbcf1bdd2aca67c79c842402b5283563d006a67cf76/mypy-1.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:9f73dba9ec77acb86457a8fc04b5239822df0c14a082564737833d2963677dbc", size = 9737709 },
+    { url = "https://files.pythonhosted.org/packages/5f/d4/b33ddd40dad230efb317898a2d1c267c04edba73bc5086bf77edeb410fb2/mypy-1.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0246bcb1b5de7f08f2826451abd947bf656945209b140d16ed317f65a17dc7dc", size = 11013906 },
+    { url = "https://files.pythonhosted.org/packages/f4/e6/f414bca465b44d01cd5f4a82761e15044bedd1bf8025c5af3cc64518fac5/mypy-1.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7f5b7deae912cf8b77e990b9280f170381fdfbddf61b4ef80927edd813163732", size = 10180657 },
+    { url = "https://files.pythonhosted.org/packages/38/e9/fc3865e417722f98d58409770be01afb961e2c1f99930659ff4ae7ca8b7e/mypy-1.13.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7029881ec6ffb8bc233a4fa364736789582c738217b133f1b55967115288a2bc", size = 12586394 },
+    { url = "https://files.pythonhosted.org/packages/2e/35/f4d8b6d2cb0b3dad63e96caf159419dda023f45a358c6c9ac582ccaee354/mypy-1.13.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3e38b980e5681f28f033f3be86b099a247b13c491f14bb8b1e1e134d23bb599d", size = 13103591 },
+    { url = "https://files.pythonhosted.org/packages/22/1d/80594aef135f921dd52e142fa0acd19df197690bd0cde42cea7b88cf5aa2/mypy-1.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:a6789be98a2017c912ae6ccb77ea553bbaf13d27605d2ca20a76dfbced631b24", size = 9634690 },
+    { url = "https://files.pythonhosted.org/packages/3b/86/72ce7f57431d87a7ff17d442f521146a6585019eb8f4f31b7c02801f78ad/mypy-1.13.0-py3-none-any.whl", hash = "sha256:9c250883f9fd81d212e0952c92dbfcc96fc237f4b7c92f56ac81fd48460b3e5a", size = 2647043 },
 ]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/60/0582ce2eaced55f65a4406fc97beba256de4b7a95a0034c6576458c6519f/mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8", size = 4252 }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/eb/975c7c080f3223a5cdaff09612f3a5221e4ba534f7039db34c35d95fa6a5/mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d", size = 4470 },
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
 ]
 
 [[package]]
@@ -1290,11 +1298,11 @@ cryptography = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.7"
+version = "0.0.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/67/94/bb4778be5d4c18329d60276d4e58b3974e2dce8ec3bee5569bfe9c81f36e/python_multipart-0.0.7.tar.gz", hash = "sha256:288a6c39b06596c1b988bb6794c6fbc80e6c369e35e5062637df256bee0c9af9", size = 31129 }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/35/142fff3d85da49377ada6936ad9b776263549ab22656969b2fcd0bdb10f7/python_multipart-0.0.7-py3-none-any.whl", hash = "sha256:b1fef9a53b74c795e2347daac8c54b252d9e0df9c619712691c1cc8021bd3c49", size = 22191 },
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546 },
 ]
 
 [[package]]
@@ -1532,15 +1540,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.26.1"
+version = "0.41.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/55/98746af96f57a0ff4f108c5ac84c130af3c4e291272acf446afc67d5d5d8/starlette-0.26.1.tar.gz", hash = "sha256:41da799057ea8620e4667a3e69a5b1923ebd32b1819c8fa75634bbe8d8bea9bd", size = 51307 }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/4c/9b5764bd22eec91c4039ef4c55334e9187085da2d8a2df7bd570869aae18/starlette-0.41.3.tar.gz", hash = "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835", size = 2574159 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/48/f9c1ec6bee313aba264fbc2483d9070f4e4526f2538e2b55b1e4a391d938/starlette-0.26.1-py3-none-any.whl", hash = "sha256:e87fce5d7cbdde34b76f0ac69013fd9d190d581d80681493016666e6f96c6d5e", size = 66917 },
+    { url = "https://files.pythonhosted.org/packages/96/00/2b325970b3060c7cecebab6d295afe763365822b1306a12eeab198f74323/starlette-0.41.3-py3-none-any.whl", hash = "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7", size = 73225 },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #269.

Originally wanted to update just python-multipart, but then it complained about FastAPI's old way of importing it; thus I've decided to update FastAPI as well. And mypy also made sense, to reduce some of the false positives.

FastAPI is now using `examples=[…]` instead of `example=…`.

Got rid of some `type: ignore` markers by debugging the root cause.

Updated the log filter to return bools instead of 0 and 1.

The new `type: ignore` markers in `progress.py` are unfortunate, but that code is complicated and I don't have the time to thoroughly fix it, and especially make sure that I didn't break anything, right now.