### PR TITLE
Replace requests with httpx

### DIFF
--- a/server/dearmep/phone/elks/elks.py
+++ b/server/dearmep/phone/elks/elks.py
@@ -7,7 +7,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, Optional, Union
 
-import requests
+import httpx
 from fastapi import (
     APIRouter,
     Depends,
@@ -67,7 +67,7 @@ def send_sms(
         provider_cfg.username,
         provider_cfg.password,
     )
-    response = requests.post(
+    response = httpx.post(
         url="https://api.46elks.com/a1/sms",
         timeout=10,
         auth=auth,
@@ -77,7 +77,7 @@ def send_sms(
             "message": message,
         },
     )
-    if not response.ok:
+    if not response.is_success:
         _logger.critical(
             f"46elks request to send sms failed: {response.status_code}"
         )
@@ -123,7 +123,7 @@ def start_elks_call(
         phone_numbers=phone_numbers,
     )
 
-    response = requests.post(
+    response = httpx.post(
         url="https://api.46elks.com/a1/calls",
         timeout=10,
         auth=auth,
@@ -136,7 +136,7 @@ def start_elks_call(
         },
     )
 
-    if not response.ok:
+    if not response.is_success:
         _logger.critical(
             f"46elks request to start call failed: {response.status_code}"
         )

--- a/server/dearmep/phone/elks/utils.py
+++ b/server/dearmep/phone/elks/utils.py
@@ -5,7 +5,7 @@
 import logging
 from random import choice
 
-import requests
+import httpx
 
 from ...config import Language
 from .models import Number
@@ -49,7 +49,7 @@ def get_numbers(
     Fetches all available numbers of an account at 46elks.
     """
 
-    response = requests.get(
+    response = httpx.get(
         url="https://api.46elks.com/a1/numbers", timeout=10, auth=auth
     )
     if response.status_code != 200:  # noqa: PLR2004

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
 	"pytz~=2023.3.post1",
 	"pyyaml~=6.0",
 	"ratelimit~=2.2.1",
-	"requests~=2.31",
 	"rich~=13.4.2",
 	"sqlmodel<0.0.11",
 	"starlette-exporter~=0.15.1",
@@ -59,7 +58,6 @@ dev = [
 	"types-pillow~=9.5.0.5",
 	"types-pytz~=2023.3.1.1",
 	"types-pyyaml~=6.0.12.2",
-	"types-requests~=2.31.0.1",
 ]
 
 [project.scripts]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -208,15 +208,6 @@ wheels = [
 ]
 
 [[package]]
-name = "charset-normalizer"
-version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/34/44964211e5410b051e4b8d2869c470ae8a68ae274953b1c7de6d98bbcf94/charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845", size = 82360 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f", size = 39748 },
-]
-
-[[package]]
 name = "click"
 version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -374,7 +365,6 @@ dependencies = [
     { name = "pytz" },
     { name = "pyyaml" },
     { name = "ratelimit" },
-    { name = "requests" },
     { name = "rich" },
     { name = "sqlmodel" },
     { name = "starlette-exporter" },
@@ -405,7 +395,6 @@ dev = [
     { name = "types-pillow" },
     { name = "types-pytz" },
     { name = "types-pyyaml" },
-    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -434,7 +423,6 @@ requires-dist = [
     { name = "pytz", specifier = "~=2023.3.post1" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "ratelimit", specifier = "~=2.2.1" },
-    { name = "requests", specifier = "~=2.31" },
     { name = "rich", specifier = "~=13.4.2" },
     { name = "sqlmodel", specifier = "<0.0.11" },
     { name = "starlette-exporter", specifier = "~=0.15.1" },
@@ -457,7 +445,6 @@ dev = [
     { name = "types-pillow", specifier = "~=9.5.0.5" },
     { name = "types-pytz", specifier = "~=2023.3.1.1" },
     { name = "types-pyyaml", specifier = "~=6.0.12.2" },
-    { name = "types-requests", specifier = "~=2.31.0.1" },
 ]
 
 [[package]]
@@ -1381,21 +1368,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/38/ff60c8fc9e002d50d48822cc5095deb8ebbc5f91a6b8fdd9731c87a147c9/ratelimit-2.2.1.tar.gz", hash = "sha256:af8a9b64b821529aca09ebaf6d8d279100d766f19e90b5059ac6a718ca6dee42", size = 5251 }
 
 [[package]]
-name = "requests"
-version = "2.31.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1", size = 110794 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f", size = 62574 },
-]
-
-[[package]]
 name = "rfc3986"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1669,27 +1641,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-requests"
-version = "2.31.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "types-urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/8e/2f846f4295021703d4f12aebf504dd5e47b7750d104ee0a8fd253f601d02/types-requests-2.31.0.1.tar.gz", hash = "sha256:3de667cffa123ce698591de0ad7db034a5317457a596eb0b4944e5a9d9e8d1ac", size = 15151 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/09/d89e773735e444828f8d5a4b11f8a940e314ae05c6ccedfc94e44861e97e/types_requests-2.31.0.1-py3-none-any.whl", hash = "sha256:afb06ef8f25ba83d59a1d424bd7a5a939082f94b94e90ab5e6116bd2559deaa3", size = 14355 },
-]
-
-[[package]]
-name = "types-urllib3"
-version = "1.26.25.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/2a/cb418a2a03a31b8e0daea5e13edcc4ef1408ebb457f2cc833f1c3f30a0fa/types-urllib3-1.26.25.13.tar.gz", hash = "sha256:3300538c9dc11dad32eae4827ac313f5d986b8b21494801f1bf97a1ac6c03ae5", size = 11035 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/6d/98b51f9776747e1e270919aa02298ce6a7d2d4d78a3349b47666deb61c4c/types_urllib3-1.26.25.13-py3-none-any.whl", hash = "sha256:5dbd1d2bef14efee43f5318b5d36d805a489f6600252bb53626d4bfafd95e27c", size = 15215 },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1705,15 +1656,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/34/943888654477a574a86a98e9896bae89c7aa15078ec29f490fef2f1e5384/tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc", size = 193282 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/ab/7e5f53c3b9d14972843a647d8d7a853969a58aecc7559cb3267302c94774/tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd", size = 346586 },
-]
-
-[[package]]
-name = "urllib3"
-version = "1.26.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/56/d87d6d3c4121c0bcec116919350ca05dc3afd2eeb7dc88d07e8083f8ea94/urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e", size = 299806 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/de/5be2e3eed8426f871b170663333a0f627fc2924cc386cd41be065e7ea870/urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997", size = 140381 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes a security issue with requests, and makes sure we're using only one HTTP library.

Untested (except for mypy and tests), will do that later when all the package updates have been merged.

Fixes #280.