### PR TITLE
Add CSS custom property for primary button text color

### DIFF
--- a/client/src/style/dear-mep-inner.scss
+++ b/client/src/style/dear-mep-inner.scss
@@ -128,6 +128,9 @@
     min-height: 6em;
     background-color: var(--dmep-btn-primary-bg-color);
   }
+  .dmep-btn-primary:not(:disabled) {
+    color: var(--dmep-btn-primary-text-color);
+  }
   .dmep-btn-primary[disabled] {
     background-color: unset;
   }

--- a/client/src/style/themes/variables.scss
+++ b/client/src/style/themes/variables.scss
@@ -45,6 +45,7 @@
 
   // Buttons
   --dmep-btn-primary-bg-color: rgb(255, 255, 255);
+  --dmep-btn-primary-text-color: rgb(250, 128, 114);
 
   // Gaps
   --dmep-layout-gap: 40px;


### PR DESCRIPTION
While the primary button's background is already themeable through CSS custom properties, its text color is not. I have added an additional custom property for the text color of the non-disabled primary button.

I'm aware that the background-color is simply set in a rule for `.dmep-btn-primary` and then overridden for `[disabled]`. However in this case the selector needs to include `:not(:disabled)` so that it has higher specificity than the Angular Material selector `.mat-mdc-outlined-button:not(:disabled)`.