### PR TITLE
Return 400 when verifying invalid phone numbers

### DIFF
--- a/server/dearmep/api/v1.py
+++ b/server/dearmep/api/v1.py
@@ -531,7 +531,11 @@ def request_number_verification(
             PhoneNumberVerificationRejectedResponse(errors=errors),
         )
 
-    user = UserPhone(request.phone_number)
+    try:
+        user = UserPhone(request.phone_number)
+    except ValueError:
+        return reject([PhoneRejectReason.INVALID_PATTERN])
+
     # The `assert` is just to guarantee to mypy that it's not None. Which we
     # can guarantee because we've just created this UserPhone from an actual
     # unhashed phone number.

--- a/server/tests/api/test_number_verification.py
+++ b/server/tests/api/test_number_verification.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: © 2025 Tim Weber
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+
+def test_invalid_number(client: TestClient):
+    res = client.post(
+        "/api/v1/number-verification/request",
+        json={"language": "de", "accepted_dpp": True, "phone_number": "+44 1"},
+    )
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+    data = res.json()
+    assert data == {"errors": ["INVALID_PATTERN"]}


### PR DESCRIPTION
Before, this would throw a `ValueError`, resulting in HTTP 500.

Reported by @t-muehlberger, thanks!