### PR TITLE
Remove `category` from 46elks phone numbers

### DIFF
--- a/server/dearmep/phone/elks/models.py
+++ b/server/dearmep/phone/elks/models.py
@@ -21,7 +21,6 @@ class InitialCallElkResponse(BaseModel):
 
 
 class Number(BaseModel):
-    category: Literal["fixed", "mobile", "voip"]
     country: str
     expires: datetime
     number: str


### PR DESCRIPTION
It's not guaranteed to be returned from the API and undocumented.