### PR TITLE
Apply primary button text color to small primary button as well

### DIFF
--- a/client/src/style/dear-mep-inner.scss
+++ b/client/src/style/dear-mep-inner.scss
@@ -128,7 +128,8 @@
     min-height: 6em;
     background-color: var(--dmep-btn-primary-bg-color);
   }
-  .dmep-btn-primary:not(:disabled) {
+  .dmep-btn-primary:not(:disabled),
+  .dmep-btn-primary-sm:not(:disabled) {
     color: var(--dmep-btn-primary-text-color);
   }
   .dmep-btn-primary[disabled] {


### PR DESCRIPTION
Since the background color from the CSS custom property is applied to both `.dmep-btn-primary` and `.dmep-btn-primary-sm`, it makes sense to apply the text color to both as well.