### PR TITLE
Enforce DB fields to be timezone-aware, store UTC

### DIFF
--- a/server/dearmep/database/query.py
+++ b/server/dearmep/database/query.py
@@ -552,7 +552,7 @@ def get_number_verification_count(
             NumberVerificationRequest.requested_at
             > func.coalesce(
                 last_successful,
-                datetime(2000, 1, 1),  # noqa: DTZ001
+                datetime(2000, 1, 1, tzinfo=timezone.utc),
             )
         )
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -207,6 +207,8 @@ ignore = [
 [tool.ruff.lint.flake8-annotations]
 # Allow __init__ to omit the `-> None` return type declaration.
 mypy-init-return = true
+# Don't require type annotations for variables starting with an underscore.
+suppress-dummy-args = true
 
 [tool.ruff.lint.flake8-bugbear]
 # Allow FastAPI's request data type hints as default arguments in functions.

--- a/server/tests/test_ongoing_calls.py
+++ b/server/tests/test_ongoing_calls.py
@@ -47,6 +47,8 @@ def test_ongoing_calls_interface(client: TestClient):
         assert call.provider_call_id == provider_call_id
         assert call.user_language == user_language
         assert call.provider == provider
+        # timestamp has to be timezone-aware
+        assert call.started_at.tzinfo is not None
         # call is not connected yet
         # check call instance and via interface method
         assert call.connected_at is None

--- a/server/tests/test_timezones.py
+++ b/server/tests/test_timezones.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2025 Tim Weber
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from datetime import datetime, timezone
+
+import pytest
+import pytz
+from sqlalchemy.exc import StatementError
+from sqlmodel import Session, select, text
+
+from dearmep.database.models import Blob
+
+
+def test_timestamps_in_db(
+    session: Session, fastapi_app, with_example_destinations
+):
+    # Creating a blob with an automatic timestamp should just work.
+    blob = Blob(type="test", mime_type="text/plain", name="test", data=b"test")
+    session.add(blob)
+    session.commit()
+    # The timestamp should now be populated.
+    assert blob.modified_at is not None
+    # The timestamp should be in UTC.
+    assert blob.modified_at.tzinfo == timezone.utc
+    # The timestamp should be pretty close to "now".
+    assert (
+        abs((blob.modified_at - datetime.now(tz=timezone.utc)).total_seconds())
+        < 10  # noqa: PLR2004
+    )
+
+    # Let's try creating a blob with a given, naive timestamp. Should fail.
+    blob = Blob(
+        type="test",
+        mime_type="text/plain",
+        name="test-naive",
+        data=b"test",
+        modified_at=datetime.now(tz=None),  # noqa: DTZ005
+    )
+    session.add(blob)
+    with pytest.raises(StatementError, match="naive datetime"):
+        session.commit()
+    session.rollback()
+
+    # Create the blob with a given aware timestamp.
+    modified = pytz.timezone("America/Belize").localize(
+        datetime(2025, 9, 18, 16, 0, 23)  # noqa: DTZ001
+    )
+    blob = Blob(
+        type="test",
+        mime_type="text/plain",
+        name="test-aware",
+        data=b"test",
+        modified_at=modified,
+    )
+    session.add(blob)
+    session.commit()
+    # Retrieve the blob again.
+    blob = session.exec(select(Blob).where(Blob.name == "test-aware")).one()
+    # Ensure that its timestamp matches what we expect.
+    assert blob.modified_at == modified
+    assert (
+        blob.modified_at
+        - datetime(2025, 9, 18, 22, 0, 23, tzinfo=timezone.utc)
+    ).total_seconds() == 0
+    # Finally, check what's in the database.
+    assert (
+        session.execute(
+            text("select modified_at from blobs where name = 'test-aware'")
+        )
+        .one()
+        .modified_at.startswith("2025-09-18 22:00:23")
+    )


### PR DESCRIPTION
This ensures that values read from the database will be timezone-aware datetimes (using UTC). Values written to the database need to be timezone-aware, too, and will be converted to UTC upon writing.

Also comes with a test to make sure I didn't mess this up.

Fixes #326.