### PR TITLE
Allow setting a time limit for conversations

### DIFF
--- a/server/dearmep/config.py
+++ b/server/dearmep/config.py
@@ -326,6 +326,7 @@ class TelephonyConfig(BaseModel):
     dry_run: bool = False
     office_hours: OfficeHoursConfig
     successful_call_duration: PositiveInt
+    connected_call_timeout: Union[PositiveInt, Literal[False]] = False
     provider: ElksConfig
     audio_source: Path
     always_connect_to: Optional[str]

--- a/server/dearmep/example-config.yaml
+++ b/server/dearmep/example-config.yaml
@@ -251,6 +251,13 @@ telephony:
   # conversation with MEPs. In seconds.
   successful_call_duration: 35
 
+  # After a User has been connected to a Destination (i.e., an MEP), how long
+  # may they talk to each other (in seconds)? After this time, the call will be
+  # terminated without any further notice. This option acts as a safety measure
+  # to prevent excessively long conversations and their associated costs. Can be
+  # set to false to completely disable the timeout.
+  connected_call_timeout: 900  # 15 minutes
+
   # It does not make sense to call representatives' offices in the middle of
   # the night. Therefore, you can configure "office hours". Outside of the time
   # range defined here, starting new calls will not be possible.

--- a/server/dearmep/phone/elks/elks.py
+++ b/server/dearmep/phone/elks/elks.py
@@ -767,11 +767,13 @@ def mount_router(app: FastAPI, prefix: str) -> None:  # noqa: C901, PLR0915
                 destination_number=connect_number, our_number=from_number
             )
             ongoing_calls.connect_call(call, session)
-            connect = {
+            connect: dict[str, Union[str, int]] = {
                 "connect": connect_number,
             }
             if telephony_cfg.always_connect_to:
                 connect["connect"] = telephony_cfg.always_connect_to
+            if telephony_cfg.connected_call_timeout:
+                connect["timelimit"] = telephony_cfg.connected_call_timeout
 
             query.log_destination_selection(
                 session=session,


### PR DESCRIPTION
This is untested and using a currently undocumented option in the 46elks API to set the time limit, which they may or may not have developed mainly for us.