### PR TITLE
Do not use moreArgumentsHtml translation key if it does not exist

### DIFF
--- a/client/src/app/components/talking-points/talking-points.component.html
+++ b/client/src/app/components/talking-points/talking-points.component.html
@@ -12,7 +12,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       <p>{{ talkingPoint.body }}</p>
     </div>
   }
-  @if (t('talkingPoints.moreArgumentsHtml')) {
+  <!-- It seems that currently there is no intrinsic way to check if a key exists so this is the workaround -->
+  @if (t('talkingPoints.moreArgumentsHtml') !== 'talkingPoints.moreArgumentsHtml') {
     <div
       class="dmep-more-arguments"
       [innerHTML]="

--- a/client/src/app/components/talking-points/talking-points.component.html
+++ b/client/src/app/components/talking-points/talking-points.component.html
@@ -13,7 +13,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     </div>
   }
   <!-- It seems that currently there is no intrinsic way to check if a key exists so this is the workaround -->
-  @if (t('talkingPoints.moreArgumentsHtml') !== 'talkingPoints.moreArgumentsHtml') {
+  @if (
+    t('talkingPoints.moreArgumentsHtml') !== 'talkingPoints.moreArgumentsHtml'
+  ) {
     <div
       class="dmep-more-arguments"
       [innerHTML]="


### PR DESCRIPTION
Correctly check if optional translation key exists before using it.

Closes #330 